### PR TITLE
Standardize theme-aware UI controls

### DIFF
--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -40,10 +40,7 @@ const AdminDashboard: React.FC = () => {
             <button
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
-              className={`flex items-center px-4 py-3 text-sm font-medium border-b-2 transition-colors duration-200 ${activeTab === tab.id
-                ? 'border-primary text-primary'
-                : 'border-transparent text-text-muted hover:text-primary hover:bg-primary/5'
-                }`}
+              className={`app-tab ${activeTab === tab.id ? 'is-active' : ''}`}
               data-testid={`tab-${tab.id}`}
             >
               {tab.icon}

--- a/components/admin/ChatLogsViewer.tsx
+++ b/components/admin/ChatLogsViewer.tsx
@@ -43,7 +43,7 @@ const ChatLogsViewer: React.FC = () => {
                   <li key={log.id}>
                     <button
                       onClick={() => setSelectedLog(log)}
-                      className={`w-full text-left p-3 rounded-lg transition-colors ${selectedLog?.id === log.id ? 'bg-primary text-white' : 'hover:bg-primary/5 text-text'}`}
+                      className={`app-button w-full text-left justify-start ${selectedLog?.id === log.id ? 'app-button-primary' : 'app-button-secondary'}`}
                     >
                       <p className="font-semibold text-sm">User: {log.userId}</p>
                       <p className="text-xs opacity-80">{new Date(log.timestamp).toLocaleString()}</p>

--- a/components/admin/FeedbackViewer.tsx
+++ b/components/admin/FeedbackViewer.tsx
@@ -11,7 +11,7 @@ const FeedbackDetailsModal: React.FC<{ feedback: UserFeedback, onClose: () => vo
             <div className="bg-surface rounded-lg shadow-xl p-6 w-full max-w-3xl max-h-[90vh] overflow-y-auto border border-border">
                 <div className="flex justify-between items-center border-b border-border pb-3 mb-4">
                     <h3 className="text-xl font-semibold text-text">Feedback Details</h3>
-                    <button onClick={onClose} className="p-1 rounded-full hover:bg-text-muted/20 text-text">
+                    <button onClick={onClose} className="app-button app-button-ghost p-1 rounded-full">
                         <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                     </button>
                 </div>
@@ -138,7 +138,7 @@ const FeedbackViewer: React.FC = () => {
                                             <td className="px-6 py-4 text-right">
                                                 <button
                                                     onClick={() => setSelectedFeedback(item)}
-                                                    className="font-medium text-primary hover:underline">
+                                                    className="app-button app-button-secondary text-sm">
                                                     View Details
                                                 </button>
                                             </td>

--- a/components/admin/FeedbackViewer.tsx
+++ b/components/admin/FeedbackViewer.tsx
@@ -11,7 +11,7 @@ const FeedbackDetailsModal: React.FC<{ feedback: UserFeedback, onClose: () => vo
             <div className="bg-surface rounded-lg shadow-xl p-6 w-full max-w-3xl max-h-[90vh] overflow-y-auto border border-border">
                 <div className="flex justify-between items-center border-b border-border pb-3 mb-4">
                     <h3 className="text-xl font-semibold text-text">Feedback Details</h3>
-                    <button onClick={onClose} className="app-button app-button-ghost p-1 rounded-full">
+                    <button onClick={onClose} className="app-button app-button-ghost rounded-full">
                         <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                     </button>
                 </div>

--- a/components/admin/KnowledgeBaseManager.tsx
+++ b/components/admin/KnowledgeBaseManager.tsx
@@ -278,10 +278,10 @@ const KnowledgeBaseManager: React.FC = () => {
                     <span className="text-sm text-text truncate">{source.type === 'text' ? `${source.content.substring(0, 70)}...` : source.content}</span>
                   </div>
                   <div className="flex space-x-2">
-                    <button onClick={() => setEditingSource(source)} aria-label="Edit source" className="app-button app-button-ghost p-1 rounded-full" data-testid={`edit-kb-source-${source.id}`}>
+                    <button onClick={() => setEditingSource(source)} aria-label="Edit source" className="app-button-icon app-button-ghost" data-testid={`edit-kb-source-${source.id}`}>
                       <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.5L15.232 5.232z" /></svg>
                     </button>
-                    <button onClick={() => handleDelete(source.id)} aria-label="Delete source" className="app-button app-button-danger p-1 rounded-full" data-testid={`delete-kb-source-${source.id}`}>
+                    <button onClick={() => handleDelete(source.id)} aria-label="Delete source" className="app-button-icon app-button-danger" data-testid={`delete-kb-source-${source.id}`}>
                       <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
                     </button>
                   </div>

--- a/components/admin/KnowledgeBaseManager.tsx
+++ b/components/admin/KnowledgeBaseManager.tsx
@@ -205,7 +205,7 @@ const KnowledgeBaseManager: React.FC = () => {
         <form onSubmit={handleSubmit}>
           <div className="flex space-x-2 mb-4 border-b border-border">
             {(Object.values(KnowledgeSourceType)).map(type => (
-              <button key={type} type="button" onClick={() => { setNewSourceType(type); setValidationError(null); }} className={`capitalize px-4 py-2 text-sm font-medium border-b-2 transition-colors ${newSourceType === type ? 'border-primary text-primary' : 'border-transparent text-text-muted hover:text-text'}`}>
+              <button key={type} type="button" onClick={() => { setNewSourceType(type); setValidationError(null); }} className={`app-tab capitalize ${newSourceType === type ? 'is-active' : ''}`}>
                 {type}
               </button>
             ))}
@@ -218,7 +218,7 @@ const KnowledgeBaseManager: React.FC = () => {
             type="submit"
             aria-busy={isSubmitting}
             disabled={isSubmitting}
-            className="bg-secondary text-brand-dark font-medium px-4 py-2 rounded-lg hover:bg-secondary/90 transition-colors disabled:bg-text-muted/30 disabled:cursor-wait flex items-center justify-center min-w-[140px]"
+            className="app-button app-button-primary min-w-[140px]"
             data-testid="add-kb-source-button"
           >
             {isSubmitting ? (
@@ -245,7 +245,7 @@ const KnowledgeBaseManager: React.FC = () => {
           <button
             onClick={handleReIndex}
             disabled={isIndexing}
-            className="bg-primary/10 text-primary px-4 py-2 text-sm font-semibold rounded-lg hover:bg-primary/20 transition-colors disabled:bg-neutral-200 disabled:text-neutral-500 disabled:cursor-wait flex items-center justify-center gap-2"
+            className="app-button app-button-secondary text-sm"
             data-testid="reindex-kb-button"
           >
             {isIndexing && <Spinner />}
@@ -278,10 +278,10 @@ const KnowledgeBaseManager: React.FC = () => {
                     <span className="text-sm text-text truncate">{source.type === 'text' ? `${source.content.substring(0, 70)}...` : source.content}</span>
                   </div>
                   <div className="flex space-x-2">
-                    <button onClick={() => setEditingSource(source)} aria-label="Edit source" className="text-primary hover:text-text p-1 rounded-full hover:bg-primary/10 transition-colors" data-testid={`edit-kb-source-${source.id}`}>
+                    <button onClick={() => setEditingSource(source)} aria-label="Edit source" className="app-button app-button-ghost p-1 rounded-full" data-testid={`edit-kb-source-${source.id}`}>
                       <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.5L15.232 5.232z" /></svg>
                     </button>
-                    <button onClick={() => handleDelete(source.id)} aria-label="Delete source" className="text-red-500 hover:text-red-700 p-1 rounded-full hover:bg-red-100 transition-colors" data-testid={`delete-kb-source-${source.id}`}>
+                    <button onClick={() => handleDelete(source.id)} aria-label="Delete source" className="app-button app-button-danger p-1 rounded-full" data-testid={`delete-kb-source-${source.id}`}>
                       <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
                     </button>
                   </div>
@@ -310,8 +310,8 @@ const KnowledgeBaseManager: React.FC = () => {
             />
             <p className="text-xs text-text-muted mt-2">Note: Editing content for URL or file sources is disabled. To update, please delete and re-add. Saving changes will re-generate the vector embedding.</p>
             <div className="mt-4 flex justify-end space-x-2">
-              <button onClick={() => setEditingSource(null)} className="px-4 py-2 bg-background text-text rounded-lg hover:bg-text-muted/20 border border-border">Cancel</button>
-              <button onClick={handleUpdate} className="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90">Save Changes</button>
+              <button onClick={() => setEditingSource(null)} className="app-button app-button-secondary">Cancel</button>
+              <button onClick={handleUpdate} className="app-button app-button-primary">Save Changes</button>
             </div>
           </div>
         </div>

--- a/components/admin/PromptManager.tsx
+++ b/components/admin/PromptManager.tsx
@@ -64,7 +64,7 @@ const PromptManager: React.FC = () => {
             className="flex-grow p-2 border border-border rounded-lg bg-background text-text focus:ring-primary focus:border-primary"
             data-testid="new-greeting-input"
           />
-          <button onClick={handleAddGreeting} className="bg-secondary text-brand-dark px-4 py-2 rounded-lg hover:bg-secondary/90 transition-colors" data-testid="add-greeting-button">Add</button>
+          <button onClick={handleAddGreeting} className="app-button app-button-primary" data-testid="add-greeting-button">Add</button>
         </div>
       </div>
 
@@ -79,12 +79,12 @@ const PromptManager: React.FC = () => {
                   <button
                     onClick={() => handleSetActive(greeting.id)}
                     disabled={greeting.isActive}
-                    className={`text-xs px-3 py-1 rounded-full transition-colors disabled:cursor-not-allowed ${greeting.isActive ? 'bg-primary text-white' : 'bg-text-muted/20 text-text-muted hover:bg-primary/20 hover:text-primary'}`}
+                    className={`text-xs rounded-full disabled:cursor-not-allowed ${greeting.isActive ? "app-button app-button-primary" : "app-button app-button-secondary"}`}
                     data-testid={`set-active-greeting-${greeting.id}`}
                   >
                     {greeting.isActive ? 'Active' : 'Set Active'}
                   </button>
-                  <button onClick={() => handleDeleteGreeting(greeting.id)} className="text-red-500 hover:text-red-700 p-1 rounded-full hover:bg-red-100 transition-colors" data-testid={`delete-greeting-${greeting.id}`}>
+                  <button onClick={() => handleDeleteGreeting(greeting.id)} className="app-button app-button-danger p-1 rounded-full" data-testid={`delete-greeting-${greeting.id}`}>
                     <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                   </button>
                 </div>

--- a/components/admin/PromptManager.tsx
+++ b/components/admin/PromptManager.tsx
@@ -79,12 +79,12 @@ const PromptManager: React.FC = () => {
                   <button
                     onClick={() => handleSetActive(greeting.id)}
                     disabled={greeting.isActive}
-                    className={`text-xs rounded-full disabled:cursor-not-allowed ${greeting.isActive ? "app-button app-button-primary" : "app-button app-button-secondary"}`}
+                    className={`disabled:cursor-not-allowed ${greeting.isActive ? "app-button-pill app-button-primary" : "app-button-pill app-button-secondary"}`}
                     data-testid={`set-active-greeting-${greeting.id}`}
                   >
                     {greeting.isActive ? 'Active' : 'Set Active'}
                   </button>
-                  <button onClick={() => handleDeleteGreeting(greeting.id)} className="app-button app-button-danger rounded-full" data-testid={`delete-greeting-${greeting.id}`}>
+                  <button onClick={() => handleDeleteGreeting(greeting.id)} className="app-button-icon app-button-danger" data-testid={`delete-greeting-${greeting.id}`}>
                     <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                   </button>
                 </div>

--- a/components/admin/PromptManager.tsx
+++ b/components/admin/PromptManager.tsx
@@ -79,7 +79,7 @@ const PromptManager: React.FC = () => {
                   <button
                     onClick={() => handleSetActive(greeting.id)}
                     disabled={greeting.isActive}
-                    className={`disabled:cursor-not-allowed ${greeting.isActive ? "app-button-pill app-button-primary" : "app-button-pill app-button-secondary"}`}
+                    className={greeting.isActive ? "app-button-pill app-button-primary" : "app-button-pill app-button-secondary"}
                     data-testid={`set-active-greeting-${greeting.id}`}
                   >
                     {greeting.isActive ? 'Active' : 'Set Active'}

--- a/components/admin/PromptManager.tsx
+++ b/components/admin/PromptManager.tsx
@@ -84,7 +84,7 @@ const PromptManager: React.FC = () => {
                   >
                     {greeting.isActive ? 'Active' : 'Set Active'}
                   </button>
-                  <button onClick={() => handleDeleteGreeting(greeting.id)} className="app-button app-button-danger p-1 rounded-full" data-testid={`delete-greeting-${greeting.id}`}>
+                  <button onClick={() => handleDeleteGreeting(greeting.id)} className="app-button app-button-danger rounded-full" data-testid={`delete-greeting-${greeting.id}`}>
                     <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
                   </button>
                 </div>

--- a/components/admin/RAGQualityTester.tsx
+++ b/components/admin/RAGQualityTester.tsx
@@ -99,7 +99,7 @@ const RAGQualityTester: React.FC = () => {
           <button
             type="submit"
             disabled={isSearching || !testQuery.trim()}
-            className="w-full bg-primary text-white px-6 py-3 rounded-lg hover:bg-primary-dark transition-colors disabled:bg-text-muted/30 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            className="app-button app-button-primary w-full flex items-center justify-center gap-2"
           >
             {isSearching && <Spinner />}
             <span>{isSearching ? 'Searching...' : 'Test Query'}</span>

--- a/components/admin/SystemPromptManager.tsx
+++ b/components/admin/SystemPromptManager.tsx
@@ -62,7 +62,7 @@ const SystemPromptManager: React.FC = () => {
                             <button
                                 onClick={handleSave}
                                 disabled={isSaving}
-                                className="bg-primary text-white px-6 py-2 rounded-lg font-semibold hover:bg-primary-dark transition-colors disabled:bg-text-muted/30 disabled:cursor-not-allowed flex items-center justify-center min-w-[120px]"
+                                className="app-button app-button-primary min-w-[120px]"
                                 data-testid="save-system-prompt-button"
                             >
                                 {isSaving ? <Spinner /> : 'Save Changes'}

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -135,7 +135,7 @@ const ChatWindow: React.FC = () => {
       {/* New Session Button - Fixed at bottom left */}
       <button
         onClick={clearChat}
-        className="app-button app-button-secondary fixed bottom-8 left-8 px-4 py-2 text-sm z-50 shadow-lg"
+        className="app-button app-button-secondary fixed bottom-8 left-8 text-sm z-50 shadow-lg"
         data-testid="new-chat-button"
       >
         New Session

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -135,7 +135,7 @@ const ChatWindow: React.FC = () => {
       {/* New Session Button - Fixed at bottom left */}
       <button
         onClick={clearChat}
-        className="fixed bottom-8 left-8 px-4 py-2 bg-brand-purple/20 hover:bg-brand-purple/40 text-brand-pale border border-brand-purple/30 rounded-lg font-medium transition-all duration-300 backdrop-blur-sm text-sm z-50 shadow-lg"
+        className="app-button app-button-secondary fixed bottom-8 left-8 px-4 py-2 text-sm z-50 shadow-lg"
         data-testid="new-chat-button"
       >
         New Session

--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,24 @@
     /* #64748b (Slate-500) */
     --color-border: 226 232 240;
     /* #e2e8f0 (Slate-200) */
+
+    /* Button + Tab Tokens (default to Mystic Light) */
+    --btn-primary-bg: rgb(var(--color-primary));
+    --btn-primary-bg-hover: rgb(var(--color-primary) / 0.9);
+    --btn-primary-border: rgb(var(--color-primary-dark) / 0.7);
+    --btn-primary-text: #ffffff;
+
+    --btn-secondary-bg: rgb(var(--color-primary) / 0.08);
+    --btn-secondary-bg-hover: rgb(var(--color-primary) / 0.14);
+    --btn-secondary-border: rgb(var(--color-border));
+    --btn-secondary-text: rgb(var(--color-text));
+
+    --btn-ghost-color: rgb(var(--color-text-muted));
+    --btn-ghost-hover-bg: rgb(var(--color-primary) / 0.08);
+
+    --tab-hover-bg: rgb(var(--color-primary) / 0.08);
+    --tab-active-border: rgb(var(--color-primary));
+    --tab-active-text: rgb(var(--color-primary));
   }
 
   /* Mystic Theme */
@@ -48,6 +66,14 @@
     /* Slate-400 */
     --color-border: 63 55 75;
     /* Darker border */
+
+    --btn-secondary-bg: rgb(var(--color-surface) / 0.35);
+    --btn-secondary-bg-hover: rgb(var(--color-surface) / 0.48);
+    --btn-secondary-border: rgb(var(--color-border));
+    --btn-secondary-text: rgb(var(--color-text));
+
+    --btn-ghost-color: rgb(var(--color-text));
+    --btn-ghost-hover-bg: rgb(var(--color-primary) / 0.18);
   }
 
   /* Corporate Theme */
@@ -62,6 +88,11 @@
     /* #64748b (Slate-500) - Professional Grey */
     --color-accent: 20 184 166;
     /* #14b8a6 (Teal-500) - "Tech-forward" accent */
+
+    --btn-secondary-bg: rgb(var(--color-primary) / 0.06);
+    --btn-secondary-bg-hover: rgb(var(--color-primary) / 0.12);
+    --btn-secondary-border: rgb(var(--color-border));
+    --btn-secondary-text: rgb(var(--color-text));
   }
 
   [data-theme="corporate"].dark {
@@ -81,10 +112,82 @@
     /* Adjust accent for dark mode visibility if needed */
     --color-accent: 45 212 191;
     /* #2dd4bf (Teal-400) - Brighter teal */
+
+    --btn-secondary-bg: rgb(var(--color-surface) / 0.42);
+    --btn-secondary-bg-hover: rgb(var(--color-surface) / 0.58);
+    --btn-secondary-border: rgb(var(--color-border));
+    --btn-secondary-text: rgb(var(--color-text));
+
+    --btn-ghost-color: rgb(var(--color-text));
+    --btn-ghost-hover-bg: rgb(var(--color-primary) / 0.2);
   }
 
   body {
     @apply bg-background text-text font-sans transition-colors duration-300;
+  }
+}
+
+@layer components {
+  .app-button {
+    @apply inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed;
+  }
+
+  .app-button-primary {
+    @apply shadow-sm;
+    background-color: var(--btn-primary-bg);
+    color: var(--btn-primary-text);
+    border: 1px solid var(--btn-primary-border);
+  }
+
+  .app-button-primary:hover:not(:disabled) {
+    background-color: var(--btn-primary-bg-hover);
+  }
+
+  .app-button-secondary {
+    background-color: var(--btn-secondary-bg);
+    color: var(--btn-secondary-text);
+    border: 1px solid var(--btn-secondary-border);
+  }
+
+  .app-button-secondary:hover:not(:disabled) {
+    background-color: var(--btn-secondary-bg-hover);
+    border-color: var(--btn-active-border, var(--btn-secondary-border));
+  }
+
+  .app-button-ghost {
+    color: var(--btn-ghost-color);
+    border: 1px solid transparent;
+  }
+
+  .app-button-ghost:hover:not(:disabled) {
+    background-color: var(--btn-ghost-hover-bg);
+    color: rgb(var(--color-text));
+  }
+
+  .app-button-danger {
+    @apply text-white;
+    background-color: rgb(239 68 68 / 0.9);
+    border: 1px solid rgb(239 68 68 / 0.8);
+  }
+
+  .app-button-danger:hover:not(:disabled) {
+    background-color: rgb(220 38 38 / 0.95);
+    border-color: rgb(248 113 113 / 0.9);
+  }
+
+  .app-tab {
+    @apply inline-flex items-center px-4 py-2 text-sm font-medium border-b-2 border-transparent transition-colors duration-200 rounded-t-lg;
+    color: rgb(var(--color-text-muted));
+  }
+
+  .app-tab:hover {
+    background-color: var(--tab-hover-bg);
+    color: rgb(var(--color-text));
+  }
+
+  .app-tab.is-active {
+    border-color: var(--tab-active-border);
+    color: var(--tab-active-text);
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -41,6 +41,8 @@
     --btn-ghost-color: rgb(var(--color-text-muted));
     --btn-ghost-hover-bg: rgb(var(--color-primary) / 0.08);
 
+    --btn-active-border: rgb(var(--color-primary-dark) / 0.5);
+
     --tab-hover-bg: rgb(var(--color-primary) / 0.08);
     --tab-active-border: rgb(var(--color-primary));
     --tab-active-text: rgb(var(--color-primary));
@@ -74,6 +76,8 @@
 
     --btn-ghost-color: rgb(var(--color-text));
     --btn-ghost-hover-bg: rgb(var(--color-primary) / 0.18);
+
+    --btn-active-border: rgb(var(--color-primary-light) / 0.6);
   }
 
   /* Corporate Theme */
@@ -93,6 +97,8 @@
     --btn-secondary-bg-hover: rgb(var(--color-primary) / 0.12);
     --btn-secondary-border: rgb(var(--color-border));
     --btn-secondary-text: rgb(var(--color-text));
+
+    --btn-active-border: rgb(var(--color-primary-dark) / 0.6);
   }
 
   [data-theme="corporate"].dark {
@@ -120,6 +126,8 @@
 
     --btn-ghost-color: rgb(var(--color-text));
     --btn-ghost-hover-bg: rgb(var(--color-primary) / 0.2);
+
+    --btn-active-border: rgb(var(--color-primary) / 0.7);
   }
 
   body {
@@ -173,6 +181,16 @@
   .app-button-danger:hover:not(:disabled) {
     background-color: rgb(220 38 38 / 0.95);
     border-color: rgb(248 113 113 / 0.9);
+  }
+
+  /* Icon-only button variant with compact padding */
+  .app-button-icon {
+    @apply inline-flex items-center justify-center p-1.5 rounded-full transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed;
+  }
+
+  /* Pill-shaped button variant with smaller text */
+  .app-button-pill {
+    @apply inline-flex items-center justify-center gap-1 px-3 py-1 text-xs rounded-full font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed;
   }
 
   .app-tab {


### PR DESCRIPTION
## Summary
- add shared theme-aware CSS tokens and button/tab component classes for consistent styling
- apply standardized controls across chat new-session action and admin tabs/buttons for both themes and modes

## Testing
- npm test *(fails: existing component tests expect ThemeProvider wrapping and Playwright suites misconfigured with test.describe usage)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ae04a8ebc8328b04aeebb8d96fb9d)